### PR TITLE
Enhance notice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,18 @@ function notifyAirbrake(airbrake, options = {}) {
       err.session = req.session;
       err.ua = req.headers['User-Agent'];
 
+      err.environment = {};
+
+
+      //NOTE: The following conditional handle axios specific errors. Hmmm...
+      if(err.config) {
+        err.environment.config = err.config;
+      }
+
+      if(err.code) {
+        err.environment.code = err.code;
+      }
+     
       airbrake.notify(err);
       throw err;
     });

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,12 @@ function notifyAirbrake(airbrake, options = {}) {
       const req = ctx.request;
       const res = ctx.response;
 
+      const keys = Object.keys(err);
+      err.environment = {};
+      keys.forEach((key)=> {
+        err.environment[key] = err[key];
+      });
+
       err.url = req.url;
       err.action = req.url;
       err.component = err.component || defaultComponent;
@@ -15,18 +21,6 @@ function notifyAirbrake(airbrake, options = {}) {
       err.session = req.session;
       err.ua = req.headers['User-Agent'];
 
-      err.environment = {};
-
-
-      //NOTE: The following conditional handle axios specific errors. Hmmm...
-      if(err.config) {
-        err.environment.config = err.config;
-      }
-
-      if(err.code) {
-        err.environment.code = err.code;
-      }
-     
       airbrake.notify(err);
       throw err;
     });


### PR DESCRIPTION
This PR is really to fix the incompatibilities between the error notice `koa-airbrake` sends and the latest airbrake client library `airbrake-js`. The incompatibilities result in critical, contextual information being lost from the notice and thus makes debugging harder. Ex, on an Axios timeout error, the notice no longer contains HTTP details (url, error code etc). 

The library now conforms to the new protocol that the Airbrake now expects. Essentially emulate the following
https://github.com/airbrake/airbrake-js/blob/master/src/instrumentation/express.ts